### PR TITLE
Add a 'rename' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ Type: `String`
 
 The prefix which should be subtracted from the file path to generate the file url.
 
+#### options.rename
+Type: `Function`
+
+A function that allows the generate file url to be manipulated. For example:
+
+```
+function (url) {
+  return url.replace('.tpl.html', '.html');
+}
+```
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -68,6 +68,7 @@ module.exports = function(options){
 	 * @param [options] - The plugin options
 	 * @param [options.stripPrefix] - The prefix which should be stripped from the file path
 	 * @param [options.prefix] - The prefix which should be added to the start of the url
+	 * @param [options.rename] - A function that takes in the generated url and returns the desired manipulation.
 	 * @returns {string}
 	 */
 	function getFileUrl(file, options){
@@ -84,6 +85,11 @@ module.exports = function(options){
 		// Add the prefix
 		if(options && options.prefix){
 			url = options.prefix + url;
+		}
+
+		// Rename the url
+		if(options && options.rename){
+			url = options.rename(url);
 		}
 
 		return url;

--- a/test/expected/exampleWithRename.js
+++ b/test/expected/exampleWithRename.js
@@ -1,0 +1,36 @@
+angular.module('rename.html', []).run(['$templateCache', function($templateCache) {
+  $templateCache.put('rename.html',
+    '<!doctype html>\n' +
+    '<html>\n' +
+    '	<head>\n' +
+    '		<title>Example</title>\n' +
+    '\n' +
+    '		<meta charset="utf-8" />\n' +
+    '		<meta http-equiv="Content-type" content="text/html; charset=utf-8" />\n' +
+    '		<meta name="viewport" content="width=device-width, initial-scale=1" />\n' +
+    '		<style type="text/css">\n' +
+    '			body {\n' +
+    '				margin: 0;\n' +
+    '				padding: 0;\n' +
+    '				font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;\n' +
+    '				background-color: #f0f0f2;\n' +
+    '\n' +
+    '			}\n' +
+    '		</style>\n' +
+    '		<script type="text/javascript">\n' +
+    '			function someInlineScript(){\n' +
+    '				alert("This is some \'inline script")\n' +
+    '			}\n' +
+    '		</script>\n' +
+    '	</head>\n' +
+    '	<body>\n' +
+    '		<ul>\n' +
+    '			<li ng-repeat="item in items">{{ item.name }}</li>\n' +
+    '		</ul>\n' +
+    '		<ul>\n' +
+    '			<li ng-repeat=\'thingy in thingies\'>{{ thingy.name }}</li>\n' +
+    '		</ul>\n' +
+    '	</body>\n' +
+    '</html>\n' +
+    '');
+}]);

--- a/test/main.js
+++ b/test/main.js
@@ -67,6 +67,23 @@ describe("gulp-ng-html2js", function(){
 			testBufferedFile(params, expectedFile, done);
 		});
 
+		it("should allow a custom function to rename the generate file", function(done){
+			var expectedFile = new gutil.File({
+				path: "test/expected/exampleWithRename.js",
+				cwd: "test/",
+				base: "test/expected",
+				contents: fs.readFileSync("test/expected/exampleWithRename.js")
+			});
+
+			var params = {
+				rename: function () {
+					return "rename.html";
+				}
+			};
+
+			testBufferedFile(params, expectedFile, done);
+		});
+
 		function testBufferedFile(params, expectedFile, done){
 			var srcFile = new gutil.File({
 				path: "test/fixtures/example.html",


### PR DESCRIPTION
Added in a rename option allowing fine grained control on the file url (and a test too).
Documented the rename option in `README.md`.

For a bit of context, I have a project where each template is placed inside a `/templates` folder. This resulted in template urls like, `module/templates/list.html`. The rename option let's me strip out `/templates` really easily. 

Let me know your thoughts/if there are any issues with the code! 
