### PR TITLE
add option: declareModule, default true, to only get the moduleName

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ Type: `String`
 
 The name of the generated AngularJS module. Uses the file url if omitted.
 
+#### options.declareModule
+Type: `Boolean`
+
+Whether to attempt to declare a new module (used with options.moduleName).  True if omitted.
+
+Set this to false if options.moduleName is already declared.
+
 #### options.prefix
 Type: `String`
 

--- a/index.js
+++ b/index.js
@@ -6,6 +6,10 @@ var TEMPLATE = "angular.module(\'%s\', []).run([\'$templateCache\', function($te
 	"  $templateCache.put(\'%s\',\n    \'%s\');\n" +
 	"}]);\n";
 
+var TEMPLATE_DECLARED_MODULE = "angular.module(\'%s\').run([\'$templateCache\', function($templateCache) {\n" +
+	"  $templateCache.put(\'%s\',\n    \'%s\');\n" +
+	"}]);\n";
+
 var SINGLE_MODULE_TPL = "(function(module) {\n" +
 	"try {\n" +
 	"  module = angular.module(\'%s\');\n" +
@@ -23,6 +27,7 @@ var SINGLE_MODULE_TPL = "(function(module) {\n" +
  * request the actual HTML file anymore.
  * @param [options] - The plugin options
  * @param [options.moduleName] - The name of the module which will be generated. When omitted the fileUrl will be used.
+ * @param [options.declareModule] - Whether to try to create the module. Default true, if false it will not create options.moduleName.
  * @param [options.stripPrefix] - The prefix which should be stripped from the file path
  * @param [options.prefix] - The prefix which should be added to the start of the url
  * @returns {stream}
@@ -55,7 +60,11 @@ module.exports = function(options){
 	function generateModuleDeclaration(fileUrl, contents, options){
 		var escapedContent = escapeContent(contents);
 		if(options && options.moduleName){
-			return util.format(SINGLE_MODULE_TPL, options.moduleName, options.moduleName, fileUrl, escapedContent);
+			if (options.declareModule === false) {
+				return util.format(TEMPLATE_DECLARED_MODULE, options.moduleName, fileUrl, escapedContent);
+			} else {
+				return util.format(SINGLE_MODULE_TPL, options.moduleName, options.moduleName, fileUrl, escapedContent);
+			}
 		}
 		else{
 			return util.format(TEMPLATE, fileUrl, fileUrl, escapedContent);

--- a/test/expected/exampleWithModuleNameNoGenerate.js
+++ b/test/expected/exampleWithModuleNameNoGenerate.js
@@ -1,0 +1,36 @@
+angular.module('myAwesomePartials').run(['$templateCache', function($templateCache) {
+  $templateCache.put('fixtures/example.html',
+    '<!doctype html>\n' +
+    '<html>\n' +
+    '	<head>\n' +
+    '		<title>Example</title>\n' +
+    '\n' +
+    '		<meta charset="utf-8" />\n' +
+    '		<meta http-equiv="Content-type" content="text/html; charset=utf-8" />\n' +
+    '		<meta name="viewport" content="width=device-width, initial-scale=1" />\n' +
+    '		<style type="text/css">\n' +
+    '			body {\n' +
+    '				margin: 0;\n' +
+    '				padding: 0;\n' +
+    '				font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;\n' +
+    '				background-color: #f0f0f2;\n' +
+    '\n' +
+    '			}\n' +
+    '		</style>\n' +
+    '		<script type="text/javascript">\n' +
+    '			function someInlineScript(){\n' +
+    '				alert("This is some \'inline script")\n' +
+    '			}\n' +
+    '		</script>\n' +
+    '	</head>\n' +
+    '	<body>\n' +
+    '		<ul>\n' +
+    '			<li ng-repeat="item in items">{{ item.name }}</li>\n' +
+    '		</ul>\n' +
+    '		<ul>\n' +
+    '			<li ng-repeat=\'thingy in thingies\'>{{ thingy.name }}</li>\n' +
+    '		</ul>\n' +
+    '	</body>\n' +
+    '</html>\n' +
+    '');
+}]);

--- a/test/main.js
+++ b/test/main.js
@@ -37,6 +37,22 @@ describe("gulp-ng-html2js", function(){
 			testBufferedFile(params, expectedFile, done);
 		});
 
+		it("should use options.moduleName && options.declareModule when provided", function(done){
+			var expectedFile = new gutil.File({
+				path: "test/expected/exampleWithModuleName.js",
+				cwd: "test/",
+				base: "test/expected",
+				contents: fs.readFileSync("test/expected/exampleWithModuleNameNoGenerate.js")
+			});
+
+			var params = {
+				moduleName: "myAwesomePartials",
+				declareModule: false
+			};
+
+			testBufferedFile(params, expectedFile, done);
+		});
+
 		it("should add options.prefix to the url in the generated file", function(done){
 			var expectedFile = new gutil.File({
 				path: "test/expected/exampleWithPrefix.js",


### PR DESCRIPTION
Usage: 

``` js
.pipe(ngHtml2Js({
  moduleName: 'myApp',
  declareModule: false
}));
```

I am using the same module for my source file and my template files, and I don't want my compiled file to have 'try catch' everywhere.

This makes it so, if I set `options.declareModule` to false, it will generate templates which assume that the angular module named `options.moduleName` already exists.

Added a test for it as well. Let me know if you want anything changed, or don't like the API.
