### PR TITLE
Allow moduleName to be a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,40 @@ gulp.src("./partials/*.html")
 
 This way you end up with 1 single, minified Javascript file, which pre-loads all the (minified) HTML templates.
 
+If you have your modules sorted into directories that match the module name, you could do something like this:
+
+```
+// This picks up files like this:
+//   partials/date-picker/year.html (as well as month.html, day.html)
+//   partials/expanded-combo-box/combobox.html
+//   partials/forms/feedback.html (as well as survey.html, contact.html)
+// Returns modules like this:
+//   datePicker, expandedComboBox, forms
+gulp.src("./partials/**/*.html")
+    .pipe(ngHtml2Js({
+		moduleName: function (file) {
+			var path = file.split('/'),
+			    folder = path[path.length - 2];
+			return folder.replace(/-[a-z]/g, function (match) {
+				return match.substr(1).toUpperCase();
+			});
+		}
+	}))
+	.pipe(concat("partials.min.js"))
+	.pipe(gulp.dest('./dist/partials'));
+}
+```
+
 ## API
 
 ### ngHtml2Js(options)
 
 #### options.moduleName
-Type: `String`
+Type: `String` or `Function`
 
 The name of the generated AngularJS module. Uses the file url if omitted.
+
+When this is a function, the returned value will be the module name.  The function will be passed the vinyl file object so the module name can be determined from the path, content, last access time or any other property.  Returning `undefined` will fall back to the file url.
 
 #### options.declareModule
 Type: `Boolean`

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = function(options){
 
 		if(file.isBuffer()){
 			var filePath = getFileUrl(file, options);
-			file.contents = new Buffer(generateModuleDeclaration(filePath, String(file.contents), options));
+			file.contents = new Buffer(generateModuleDeclaration(filePath, file, options));
 			file.path = gutil.replaceExtension(file.path, ".js");
 		}
 
@@ -52,18 +52,24 @@ module.exports = function(options){
 	/**
 	 * Generates the Javascript code containing the AngularJS module which puts the HTML file into the $templateCache.
 	 * @param fileUrl - The url with which the HTML will be registered in the $templateCache.
-	 * @param contents - The contents of the HTML file.
+	 * @param file - The vinyl file object.
 	 * @param [options] - The plugin options
 	 * @param [options.moduleName] - The name of the module which will be generated. When omitted the fileUrl will be used.
 	 * @returns {string} - The generated Javascript code.
 	 */
-	function generateModuleDeclaration(fileUrl, contents, options){
-		var escapedContent = escapeContent(contents);
+	function generateModuleDeclaration(fileUrl, file, options){
+		var escapedContent = escapeContent(String(file.contents)), moduleName;
 		if(options && options.moduleName){
+			moduleName = options.moduleName;
+			if (typeof moduleName === 'function') {
+				moduleName = moduleName(file);
+			}
+		}
+		if (moduleName) {
 			if (options.declareModule === false) {
-				return util.format(TEMPLATE_DECLARED_MODULE, options.moduleName, fileUrl, escapedContent);
+				return util.format(TEMPLATE_DECLARED_MODULE, moduleName, fileUrl, escapedContent);
 			} else {
-				return util.format(SINGLE_MODULE_TPL, options.moduleName, options.moduleName, fileUrl, escapedContent);
+				return util.format(SINGLE_MODULE_TPL, moduleName, moduleName, fileUrl, escapedContent);
 			}
 		}
 		else{

--- a/test/expected/exampleWithModuleNameFunction.js
+++ b/test/expected/exampleWithModuleNameFunction.js
@@ -1,0 +1,43 @@
+(function(module) {
+try {
+  module = angular.module('okiedokie');
+} catch (e) {
+  module = angular.module('okiedokie', []);
+}
+module.run(['$templateCache', function($templateCache) {
+  $templateCache.put('fixtures/example.html',
+    '<!doctype html>\n' +
+    '<html>\n' +
+    '	<head>\n' +
+    '		<title>Example</title>\n' +
+    '\n' +
+    '		<meta charset="utf-8" />\n' +
+    '		<meta http-equiv="Content-type" content="text/html; charset=utf-8" />\n' +
+    '		<meta name="viewport" content="width=device-width, initial-scale=1" />\n' +
+    '		<style type="text/css">\n' +
+    '			body {\n' +
+    '				margin: 0;\n' +
+    '				padding: 0;\n' +
+    '				font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;\n' +
+    '				background-color: #f0f0f2;\n' +
+    '\n' +
+    '			}\n' +
+    '		</style>\n' +
+    '		<script type="text/javascript">\n' +
+    '			function someInlineScript(){\n' +
+    '				alert("This is some \'inline script")\n' +
+    '			}\n' +
+    '		</script>\n' +
+    '	</head>\n' +
+    '	<body>\n' +
+    '		<ul>\n' +
+    '			<li ng-repeat="item in items">{{ item.name }}</li>\n' +
+    '		</ul>\n' +
+    '		<ul>\n' +
+    '			<li ng-repeat=\'thingy in thingies\'>{{ thingy.name }}</li>\n' +
+    '		</ul>\n' +
+    '	</body>\n' +
+    '</html>\n' +
+    '');
+}]);
+})();

--- a/test/main.js
+++ b/test/main.js
@@ -37,6 +37,24 @@ describe("gulp-ng-html2js", function(){
 			testBufferedFile(params, expectedFile, done);
 		});
 
+		it("should use options.moduleName (function) when provided", function(done){
+			var expectedFile = new gutil.File({
+				path: "test/expected/exampleWithModuleName.js",
+				cwd: "test/",
+				base: "test/expected",
+				contents: fs.readFileSync("test/expected/exampleWithModuleNameFunction.js")
+			});
+
+			var params = {
+				moduleName: function (file) {
+					String(typeof file).should.equal('object');
+					return 'okiedokie';
+				}
+			};
+
+			testBufferedFile(params, expectedFile, done);
+		});
+
 		it("should use options.moduleName && options.declareModule when provided", function(done){
 			var expectedFile = new gutil.File({
 				path: "test/expected/exampleWithModuleName.js",
@@ -83,7 +101,7 @@ describe("gulp-ng-html2js", function(){
 			testBufferedFile(params, expectedFile, done);
 		});
 
-		it("should allow a custom function to rename the generate file", function(done){
+		it("should allow a custom function to rename the generated file", function(done){
 			var expectedFile = new gutil.File({
 				path: "test/expected/exampleWithRename.js",
 				cwd: "test/",


### PR DESCRIPTION
If you store your templates in a hierarchy which matches module names,
you can now automatically generate templates in the right module.

Added tests and updated documentation
