### PR TITLE
Ability to output `$templateCache.put` -calls only

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@ var util = require("util");
 var gutil = require("gulp-util");
 var map = require("map-stream");
 
+var TEMPLATE_PUT = "$templateCache.put(\'%s\',\n    \'%s\');";
+
 var TEMPLATE = "angular.module(\'%s\', []).run([\'$templateCache\', function($templateCache) {\n" +
 	"  $templateCache.put(\'%s\',\n    \'%s\');\n" +
 	"}]);\n";
@@ -59,6 +61,9 @@ module.exports = function(options){
 	 */
 	function generateModuleDeclaration(fileUrl, file, options){
 		var escapedContent = escapeContent(String(file.contents)), moduleName;
+		if (options && options.externalModule && options.externalModule === true) {
+			return util.format(TEMPLATE_PUT, fileUrl, escapedContent);
+		}
 		if(options && options.moduleName){
 			moduleName = options.moduleName;
 			if (typeof moduleName === 'function') {

--- a/test/expected/exampleWithExternalModule.js
+++ b/test/expected/exampleWithExternalModule.js
@@ -1,0 +1,34 @@
+$templateCache.put('fixtures/example.html',
+    '<!doctype html>\n' +
+    '<html>\n' +
+    '	<head>\n' +
+    '		<title>Example</title>\n' +
+    '\n' +
+    '		<meta charset="utf-8" />\n' +
+    '		<meta http-equiv="Content-type" content="text/html; charset=utf-8" />\n' +
+    '		<meta name="viewport" content="width=device-width, initial-scale=1" />\n' +
+    '		<style type="text/css">\n' +
+    '			body {\n' +
+    '				margin: 0;\n' +
+    '				padding: 0;\n' +
+    '				font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;\n' +
+    '				background-color: #f0f0f2;\n' +
+    '\n' +
+    '			}\n' +
+    '		</style>\n' +
+    '		<script type="text/javascript">\n' +
+    '			function someInlineScript(){\n' +
+    '				alert("This is some \'inline script")\n' +
+    '			}\n' +
+    '		</script>\n' +
+    '	</head>\n' +
+    '	<body>\n' +
+    '		<ul>\n' +
+    '			<li ng-repeat="item in items">{{ item.name }}</li>\n' +
+    '		</ul>\n' +
+    '		<ul>\n' +
+    '			<li ng-repeat=\'thingy in thingies\'>{{ thingy.name }}</li>\n' +
+    '		</ul>\n' +
+    '	</body>\n' +
+    '</html>\n' +
+    '');

--- a/test/main.js
+++ b/test/main.js
@@ -118,6 +118,21 @@ describe("gulp-ng-html2js", function(){
 			testBufferedFile(params, expectedFile, done);
 		});
 
+		it("should generate put-calls only with options.externalModule", function(done){
+			var expectedFile = new gutil.File({
+				path: "test/expected/exampleWithExternalModule.js",
+				cwd: "test/",
+				base: "test/expected",
+				contents: fs.readFileSync("test/expected/exampleWithExternalModule.js")
+			});
+
+			var params = {
+				externalModule: true
+			};
+
+			testBufferedFile(params, expectedFile, done);
+		});
+
 		function testBufferedFile(params, expectedFile, done){
 			var srcFile = new gutil.File({
 				path: "test/fixtures/example.html",


### PR DESCRIPTION
Hi, 

added the ability to strip everything but `$templateCache.put` -calls from the output. This is useful for large applications. Dozens of templates also mean dozens of unnecessary run blocks and unnecessary file size.

This is how I use it now:

```js
var tplPrefix = 'angular.module("templatesModuleName").run(function($templateCache){\n';
var tplSuffix = '\n});';

gulp.src(['src/app/**/*.tpl.html'])
    .pipe(html2js({
        externalModule: true
    }))
    .pipe(concat('templates-file-name.js'))
    .pipe(insert.wrap(tplPrefix, tplSuffix))
    .pipe(gulp.dest('tmp'));
```

With output like this:
```js
angular.module('templatesModuleName').run(function($templateCache){
$templateCache.put('module/template-name.tpl.html',
    '<h1>Hello</h1>');
$templateCache.put('other-module/template-name.tpl.html',
    '<h1>World</h1>');
//... etc
});
```

I left annotations out of this example because of [gulp-ng-annotate](https://github.com/Kagami/gulp-ng-annotate).