### PR TITLE
Added option for extensions to support typescript creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ A custom Lodash template for generating the Javacript code. The template is call
     * content: the HTML content of the input file.
     * escapedContent: the escaped HTML content of the input file. Note: the HTML content is escaped for usage in a single quoted string.
     * prettyEscapedContent: the readable, escaped HTML content of the input file.
-    
+
 Example
 
 ``` javascript
@@ -134,6 +134,11 @@ Example
   template: "$templateCache.put('<%= template.url %>', '<%= template.escapedContent %>');"
 }
 ```
+
+#### options.extension
+Type: `String`
+
+The file extension of the generated files. Defaults to .js. Can be used to generate TypeScript files and create a gulp TypeScript - job to convert them. For a working example take a look at [angular-systemjs-typescript-boilerplate](https://github.com/INSPIRATIONlabs/angular-systemjs-typescript-boilerplate)
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -44,7 +44,11 @@ module.exports = function (options) {
 
         if (file.isBuffer()) {
             file.contents = new Buffer(generateModuleDeclaration(file, options));
-            file.path = gutil.replaceExtension(file.path, ".js");
+            var extension = '.js';
+            if(options.extension) {
+              extension = options.extension;
+            }
+            file.path = gutil.replaceExtension(file.path, extension);
         }
 
         return callback(null, file);

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ module.exports = function (options) {
         if (file.isBuffer()) {
             file.contents = new Buffer(generateModuleDeclaration(file, options));
             var extension = '.js';
-            if(options.extension) {
+            if(options && options.extension) {
               extension = options.extension;
             }
             file.path = gutil.replaceExtension(file.path, extension);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-ng-html2js",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A Gulp plugin which generates AngularJS modules, which pre-load your HTML code into the $templateCache. This way AngularJS doesn't need to request the actual HTML files anymore.",
   "keywords": [
     "gulpplugin",


### PR DESCRIPTION
This is needed to automatically generate ts templates from html. The results can then be processed by the gulp-typescript - module.