### PR TITLE
exported generateModuleDeclaration function

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Example
 }
 ```
 
-#### options.extension
+### options.extension
 Type: `String`
 
 The file extension of the generated files. Defaults to .js. Can be used to generate TypeScript files and create a gulp TypeScript - job to convert them. For a working example take a look at [angular-systemjs-typescript-boilerplate](https://github.com/INSPIRATIONlabs/angular-systemjs-typescript-boilerplate)
@@ -161,6 +161,22 @@ Example
 {
   export: 'system'
 }
+```
+
+### ngHtml2Js.generateModuleDeclaration(templateFile, options)
+Allows to run plugin outside of the pipe context.
+
+Example
+
+```javascript
+var vinylFile = require('vinyl-file');
+var ngHtml2Js = require("gulp-ng-html2js");
+
+vinylFile.read('src/template.html').then(function(vf) {
+    var options = { moduleName: 'templates' }
+    var converted = ngHtml2Js.generateModuleDeclaration(vf, options);
+});
+
 ```
 
 ## License

--- a/index.js
+++ b/index.js
@@ -58,107 +58,119 @@ module.exports = function (options) {
         return callback(null, file);
     }
 
-    function generateModuleDeclaration(templateFile, options) {
-        var template = getTemplate();
-        var templateParams = getTemplateParams();
-
-        return _.template(template)(templateParams);
-
-
-        function getTemplate() {
-          var template;
-
-            if (options && options.template) {
-                return options.template;
-            }
-            else if (options && options.moduleName) {
-                if (options.declareModule === false) {
-                    template = TEMPLATES.SINGLE_DECLARED_MODULE;
-                }
-                else {
-                    return TEMPLATES.SINGLE_MODULE;
-                }
-            }
-            else {
-                template = TEMPLATES.MODULE_PER_FILE;
-            }
-
-			if (options && options.export === 'commonjs') {
-				template = TEMPLATES.COMMON_JS_EXPORTS + template;
-			}
-			else if (options && options.export === 'system') {
-				template = TEMPLATES.SYSTEM_JS_EXPORTS + template;
-			}
-
-			return template;
-        }
-
-        function getTemplateParams() {
-            var params = {
-                template: {
-                    url: getTemplateUrl()
-                }
-            };
-            params.moduleName = getModuleName(params.template.url);
-            params.template.content = String(templateFile.contents);
-            params.template.escapedContent = getEscapedTemplateContent(params.template.content);
-            params.template.prettyEscapedContent = getPrettyEscapedContent(params.template.content);
-
-            return params;
-        }
-
-        function getModuleName(templateUrl) {
-            if (options && _.isFunction(options.moduleName)) {
-                return options.moduleName(templateFile);
-            }
-            else if (options && options.moduleName) {
-                return options.moduleName;
-            }
-            else {
-                return templateUrl;
-            }
-        }
-
-        function getTemplateUrl() {
-            // Start with the relative file path
-            var url = templateFile.relative;
-
-            // Replace '\' with '/' (Windows)
-            url = url.replace(/\\/g, "/");
-
-            if (options) {
-                // Remove the stripPrefix
-                if (_.startsWith(url, options.stripPrefix)) {
-                    url = url.replace(options.stripPrefix, "");
-                }
-                // Add the prefix
-                if (options.prefix) {
-                    url = options.prefix + url;
-                }
-
-                // Rename the url
-                if (_.isFunction(options.rename)) {
-                    url = options.rename(url, templateFile);
-                }
-            }
-
-            return url;
-        }
-    }
-
-    function getEscapedTemplateContent(templateContent) {
-        return templateContent
-            .replace(/\\/g, "\\\\")
-            .replace(/'/g, "\\'")
-            .replace(/\r?\n/g, "\\n");
-    }
-
-    function getPrettyEscapedContent(templateContent) {
-        return templateContent
-            .replace(/\\/g, "\\\\")
-            .replace(/'/g, "\\'")
-            .replace(/\r?\n/g, "\\n' +\n    '");
-    }
-
     return map(ngHtml2Js);
 };
+
+/**
+ * Allows running plugin outside of the pipe context.
+ * @param [templateFile] - Vinyl file that contains html to process
+ * @param [options] - The plugin options
+ * @param [options.moduleName] - The name of the module which will be generated. When omitted the fileUrl will be used.
+ * @param [options.declareModule] - Whether to try to create the module. Default true, if false it will not create options.moduleName.
+ * @param [options.stripPrefix] - The prefix which should be stripped from the file path
+ * @param [options.prefix] - The prefix which should be added to the start of the url
+ * @returns {string}
+ */
+module.exports.generateModuleDeclaration = generateModuleDeclaration;
+
+function generateModuleDeclaration(templateFile, options) {
+    var template = getTemplate();
+    var templateParams = getTemplateParams();
+
+    return _.template(template)(templateParams);
+
+
+    function getTemplate() {
+        var template;
+
+        if (options && options.template) {
+            return options.template;
+        }
+        else if (options && options.moduleName) {
+            if (options.declareModule === false) {
+                template = TEMPLATES.SINGLE_DECLARED_MODULE;
+            }
+            else {
+                return TEMPLATES.SINGLE_MODULE;
+            }
+        }
+        else {
+            template = TEMPLATES.MODULE_PER_FILE;
+        }
+
+        if (options && options.export === 'commonjs') {
+            template = TEMPLATES.COMMON_JS_EXPORTS + template;
+        }
+        else if (options && options.export === 'system') {
+            template = TEMPLATES.SYSTEM_JS_EXPORTS + template;
+        }
+
+        return template;
+    }
+
+    function getTemplateParams() {
+        var params = {
+            template: {
+                url: getTemplateUrl()
+            }
+        };
+        params.moduleName = getModuleName(params.template.url);
+        params.template.content = String(templateFile.contents);
+        params.template.escapedContent = getEscapedTemplateContent(params.template.content);
+        params.template.prettyEscapedContent = getPrettyEscapedContent(params.template.content);
+
+        return params;
+    }
+
+    function getModuleName(templateUrl) {
+        if (options && _.isFunction(options.moduleName)) {
+            return options.moduleName(templateFile);
+        }
+        else if (options && options.moduleName) {
+            return options.moduleName;
+        }
+        else {
+            return templateUrl;
+        }
+    }
+
+    function getTemplateUrl() {
+        // Start with the relative file path
+        var url = templateFile.relative;
+
+        // Replace '\' with '/' (Windows)
+        url = url.replace(/\\/g, "/");
+
+        if (options) {
+            // Remove the stripPrefix
+            if (_.startsWith(url, options.stripPrefix)) {
+                url = url.replace(options.stripPrefix, "");
+            }
+            // Add the prefix
+            if (options.prefix) {
+                url = options.prefix + url;
+            }
+
+            // Rename the url
+            if (_.isFunction(options.rename)) {
+                url = options.rename(url, templateFile);
+            }
+        }
+
+        return url;
+    }
+}
+
+function getEscapedTemplateContent(templateContent) {
+    return templateContent
+        .replace(/\\/g, "\\\\")
+        .replace(/'/g, "\\'")
+        .replace(/\r?\n/g, "\\n");
+}
+
+function getPrettyEscapedContent(templateContent) {
+    return templateContent
+        .replace(/\\/g, "\\\\")
+        .replace(/'/g, "\\'")
+        .replace(/\r?\n/g, "\\n' +\n    '");
+}


### PR DESCRIPTION
This change allows to use function `generateModuleDeclaration` outside of `pipe` context.
Mostly just code rearrangements so that function `generateModuleDeclaration` can both - be used by `ngHtml2Js` function and be exported.
Also updated README to reflect new functionality.
No breaking changes.
The file comparison looks scary, but I just moved code around.