### PR TITLE
increase lodash dependency version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "gulp-util": "*",
-    "lodash": "^3.3.0",
+    "lodash": ">=3.3 <5",
     "map-stream": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
- `lodash` v3 is no longer supported. 
- v4 does not introduce breaking changes not supported by this lib
